### PR TITLE
Fix String engine playing ~4 semitones sharp

### DIFF
--- a/src/physical_modelling/string.rs
+++ b/src/physical_modelling/string.rs
@@ -11,7 +11,7 @@ use crate::utils::filter::{DcBlocker, FilterMode, FrequencyApproximation, Svf};
 use crate::utils::parameter_interpolator::ParameterInterpolator;
 use crate::utils::random;
 use crate::utils::units::semitones_to_ratio;
-use crate::utils::{crossfade, interpolate, one_pole};
+use crate::utils::{crossfade, one_pole};
 
 pub const DELAY_LINE_SIZE: usize = 1024;
 
@@ -158,7 +158,19 @@ impl String {
         self.iir_damping_filter
             .set_f_q(damping_f, 0.5, FrequencyApproximation::Fast);
 
-        let damping_compensation = interpolate(&LUT_SVF_SHIFT, damping_cutoff, 1.0);
+        // The original C++ `Interpolate(lut_svf_shift, damping_cutoff, 1.0f)`
+        // indexes the table with a RAW index (`damping_cutoff` ≈ 12..84). The
+        // shared `interpolate()` here clamps its index to [0, 1] first (correct
+        // for normalized-phase lookups, wrong here) — that pinned this to
+        // `LUT_SVF_SHIFT[1]` for every note, scaling the string delay by a
+        // constant and detuning it ~+4 semitones sharp. Index the table
+        // directly, matching the C++. (see sourcebox/mi-plaits-dsp-rs#6)
+        let damping_compensation = {
+            let idx = damping_cutoff.clamp(0.0, (LUT_SVF_SHIFT.len() - 2) as f32);
+            let i = idx as usize;
+            let frac = idx - i as f32;
+            LUT_SVF_SHIFT[i] + (LUT_SVF_SHIFT[i + 1] - LUT_SVF_SHIFT[i]) * frac
+        };
 
         // Linearly interpolate delay time.
         let mut delay_modulation =


### PR DESCRIPTION
`String::process` computed `damping_compensation` via the shared `interpolate(&LUT_SVF_SHIFT, damping_cutoff, 1.0)`. That helper clamps its index to [0, 1] before scaling — correct for normalized-phase lookups, but here the index is a RAW table position (`damping_cutoff` ≈ 12..84). The clamp pinned every lookup to `LUT_SVF_SHIFT[1]` (≈0.759) instead of the intended entry (≈0.978 near index 46), scaling the string delay by a constant ~1.28 and detuning the String engine ~+4.2 semitones sharp of its target f0 — regardless of note.

The original C++ `Interpolate(lut_svf_shift, damping_cutoff, 1.0f)` does not clamp the index. Index the table directly here to match, leaving the shared `interpolate()` untouched (other callers pass normalized indices and rely on the clamp).

Verified: String now tracks its `f0` (measured within ~0.1 semitone of the original C++ Plaits at C3 and C4, down from +4.2 st); `cargo test` green.

See sourcebox/mi-plaits-dsp-rs#6.